### PR TITLE
Fixed image <a> links for 'NETWORKING' and 'WORKSHOPS'

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
 
 		<!-- NETWORKING-->
 			<article class="container box style1 right">
-				<a href="#" class="image fit"><img src="images/network.jpg" alt="" /></a>
+				<div class="image fit"><img src="images/network.jpg" alt="" /></div>
 				<div class="inner">
 					<header>
 						<h2>NETWORKING</h2>
@@ -303,7 +303,7 @@
 
 		<!-- WORKSHOPS -->
 			<article class="container box style1 left">
-				<a href="#" class="image fit"><img src="images/workshop.jpg" alt="" /></a>
+				<div class="image fit"><img src="images/workshop.jpg" alt="" /></div>
 				<div class="inner">
 					<header>
 						<h2>WORKSHOPS</h2>


### PR DESCRIPTION
There were image links on the images for the sections 'NETWORKING' and 'WORKSHOPS'.
They didn't lead anywhere (they had a `href='#'`) and thus gave the impression that the website is broken / unfinished.

Simply changing the anchor tag to a `<div>` tag, keeps the styling the same, but removes the 'broken' link.